### PR TITLE
problem with sql-formatter ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "issue-repo",
   "private": true,
   "type": "module",
-  "scripts": {},
-  "packageManager": "yarn@3.2.0"
+  "scripts": {
+    "dev:ts": "tsc"
+  },
+  "packageManager": "yarn@3.2.3",
+  "dependencies": {
+    "sql-formatter": "11.0.0"
+  },
+  "devDependencies": {
+    "typescript": "4.8.4"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,2 @@
 import { format } from "sql-formatter";
-
 format("asdasd");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    // "moduleResolution": "node" // <-- this will work fine
+    "module": "NodeNext" // <-- this will not work
+    // "skipLibCheck": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,21 +3,114 @@
 
 __metadata:
   version: 6
+  cacheKey: 8
+
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
+  languageName: node
+  linkType: hard
+
+"commander@npm:^2.19.0":
+  version: 2.20.3
+  resolution: "commander@npm:2.20.3"
+  checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+  languageName: node
+  linkType: hard
+
+"discontinuous-range@npm:1.0.0":
+  version: 1.0.0
+  resolution: "discontinuous-range@npm:1.0.0"
+  checksum: 8ee88d7082445b6eadc7c03bebe6dc978f96760c45e9f65d16ca66174d9e086a9e3855ee16acf65625e1a07a846a17de674f02a5964a6aebe5963662baf8b5c8
+  languageName: node
+  linkType: hard
 
 "issue-repo@workspace:.":
   version: 0.0.0-use.local
   resolution: "issue-repo@workspace:."
+  dependencies:
+    sql-formatter: 11.0.0
+    typescript: 4.8.4
   languageName: unknown
   linkType: soft
 
-"pkg1@workspace:packages/pkg1":
-  version: 0.0.0-use.local
-  resolution: "pkg1@workspace:packages/pkg1"
-  languageName: unknown
-  linkType: soft
+"moo@npm:^0.5.0":
+  version: 0.5.1
+  resolution: "moo@npm:0.5.1"
+  checksum: 2d8c013f1f9aad8e5c7a9d4a03dbb4eecd91b9fe5e9446fbc7561fd38d4d161c742434acff385722542fe7b360fce9c586da62442379e62e4158ad49c7e1a6b7
+  languageName: node
+  linkType: hard
 
-"pkg2@workspace:packages/pkg2":
-  version: 0.0.0-use.local
-  resolution: "pkg2@workspace:packages/pkg2"
-  languageName: unknown
-  linkType: soft
+"nearley@npm:^2.20.1":
+  version: 2.20.1
+  resolution: "nearley@npm:2.20.1"
+  dependencies:
+    commander: ^2.19.0
+    moo: ^0.5.0
+    railroad-diagrams: ^1.0.0
+    randexp: 0.4.6
+  bin:
+    nearley-railroad: bin/nearley-railroad.js
+    nearley-test: bin/nearley-test.js
+    nearley-unparse: bin/nearley-unparse.js
+    nearleyc: bin/nearleyc.js
+  checksum: 42c2c330c13c7991b48221c5df00f4352c2f8851636ae4d1f8ca3c8e193fc1b7668c78011d1cad88cca4c1c4dc087425420629c19cc286d7598ec15533aaef26
+  languageName: node
+  linkType: hard
+
+"railroad-diagrams@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "railroad-diagrams@npm:1.0.0"
+  checksum: 9e312af352b5ed89c2118edc0c06cef2cc039681817f65266719606e4e91ff6ae5374c707cc9033fe29a82c2703edf3c63471664f97f0167c85daf6f93496319
+  languageName: node
+  linkType: hard
+
+"randexp@npm:0.4.6":
+  version: 0.4.6
+  resolution: "randexp@npm:0.4.6"
+  dependencies:
+    discontinuous-range: 1.0.0
+    ret: ~0.1.10
+  checksum: 3c0d440a3f89d6d36844aa4dd57b5cdb0cab938a41956a16da743d3a3578ab32538fc41c16cc0984b6938f2ae4cbc0216967e9829e52191f70e32690d8e3445d
+  languageName: node
+  linkType: hard
+
+"ret@npm:~0.1.10":
+  version: 0.1.15
+  resolution: "ret@npm:0.1.15"
+  checksum: d76a9159eb8c946586567bd934358dfc08a36367b3257f7a3d7255fdd7b56597235af23c6afa0d7f0254159e8051f93c918809962ebd6df24ca2a83dbe4d4151
+  languageName: node
+  linkType: hard
+
+"sql-formatter@npm:11.0.0":
+  version: 11.0.0
+  resolution: "sql-formatter@npm:11.0.0"
+  dependencies:
+    argparse: ^2.0.1
+    nearley: ^2.20.1
+  bin:
+    sql-formatter: bin/sql-formatter-cli.cjs
+  checksum: e0351206c8d220d0380221d05692c2282efc85d47322803714cafdecfc8dc5d90941f8f656651e7b7b95e6976dfdb2933e5c1e7ebe77a08a681d59215a9f57b4
+  languageName: node
+  linkType: hard
+
+"typescript@npm:4.8.4":
+  version: 4.8.4
+  resolution: "typescript@npm:4.8.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@4.8.4#~builtin<compat/typescript>":
+  version: 4.8.4
+  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=a1c5e5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 563a0ef47abae6df27a9a3ab38f75fc681f633ccf1a3502b1108e252e187787893de689220f4544aaf95a371a4eb3141e4a337deb9895de5ac3c1ca76430e5f0
+  languageName: node
+  linkType: hard


### PR DESCRIPTION
After upgrading to `sql-formatter@11.0.0`, my project no-longer compiles.

### Step to reproduce

Checkout the code from https://github.com/akphi/issue-repo/pull/10
Run `tsc`:

```sh
yarn install
yarn dev:ts
```

I got the following error:

```
// skipLibCheck=true

src/index.ts:1:10 - error TS2305: Module '"sql-formatter"' has no exported member 'format'.

1 import { format } from "sql-formatter";
           ~~~~~~


// skipLibCheck=false

node_modules/sql-formatter/lib/src/index.d.ts:1:15 - error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.

1 export * from './sqlFormatter';
                ~~~~~~~~~~~~~~~~

node_modules/sql-formatter/lib/src/index.d.ts:2:102 - error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.

2 export type { IndentStyle, KeywordCase, CommaPosition, LogicalOperatorNewline, FormatOptions, } from './FormatOptions';
                                                                                                       ~~~~~~~~~~~~~~~~~

node_modules/sql-formatter/lib/src/index.d.ts:3:38 - error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.

3 export { default as Formatter } from './formatter/Formatter';
                                       ~~~~~~~~~~~~~~~~~~~~~~~

node_modules/sql-formatter/lib/src/index.d.ts:4:38 - error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.

4 export { default as Tokenizer } from './lexer/Tokenizer';
                                       ~~~~~~~~~~~~~~~~~~~

node_modules/sql-formatter/lib/src/index.d.ts:5:31 - error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.

5 export { expandPhrases } from './expandPhrases';
                                ~~~~~~~~~~~~~~~~~

src/index.ts:1:10 - error TS2305: Module '"sql-formatter"' has no exported member 'format'.

1 import { format } from "sql-formatter";
           ~~~~~~


Found 6 errors in 2 files.

Errors  Files
     5  node_modules/sql-formatter/lib/src/index.d.ts:1
     1  src/index.ts:1
```

My `tsconfig` looks like this:

```jsonc
{
  "compilerOptions": {
    // "moduleResolution": "node" // <-- this will work fine
    "module": "NodeNext", // <-- this will not work
    // "skipLibCheck": true
  }
}
```

I think the latest upgrade of `sql-formatter` does not work fine with Typescript module type `NodeNext`. Since we mentioned that we will fully support `ESM`, we should follow the specs and add extensions to the import statements.